### PR TITLE
Add Native-AOT support for osx-arm64

### DIFF
--- a/GitHubActionTriggerCLI/GitHubActionTriggerCLI.csproj
+++ b/GitHubActionTriggerCLI/GitHubActionTriggerCLI.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitHubActionTriggerOnnxRAGCLI/bld.bash
+++ b/GitHubActionTriggerOnnxRAGCLI/bld.bash
@@ -56,5 +56,7 @@ cat > Facts/BGE-MICRO-V2.txt <<EOF
 BGE-MICRO-V2 is a compact embedding model designed for generating dense vector representations of text. These embeddings are useful for tasks like clustering and semantic search. Due to its small size, BGE-MICRO-V2 is well-suited for deployment on devices with limited resources, offering fast inference times with a slight trade-off in accuracy compared to larger models.
 EOF
 
+# Publish the application for osx-arm64
+dotnet publish -r osx-arm64 --self-contained -c Release
 
 echo "Facts directory and files created successfully."

--- a/README.md
+++ b/README.md
@@ -144,3 +144,27 @@ Version Control: Use version control systems to track changes in data, model par
 Monitoring and Logging: Establish robust monitoring to track model performance in production, and implement logging mechanisms to capture any issues or anomalies.
 Feedback Loops: Create mechanisms for stakeholders to provide feedback on model outputs, enabling continuous improvement and alignment with business objectives.
 By following this approach, K8sLogBotRAG can leverage Azure Databricks to enhance its log analysis capabilities, ensuring it remains effective and responsive to evolving patterns within Kubernetes environments.
+
+## Generating a Native-AOT Application for `osx-arm64`
+
+To generate a Native-AOT application for `osx-arm64`, follow these steps:
+
+1. **Publish the Application:**
+
+   ```bash
+   dotnet publish -r osx-arm64 --self-contained -c Release
+   ```
+
+2. **Verify the Output:**
+
+   After publishing, verify that the output directory contains the necessary files for the `osx-arm64` runtime.
+
+3. **Run the Application:**
+
+   Navigate to the output directory and run the application:
+
+   ```bash
+   ./YourApplicationName
+   ```
+
+This will generate a self-contained, Native-AOT application for the `osx-arm64` runtime.


### PR DESCRIPTION
Related to #50

Add support for generating a Native-AOT application for `osx-arm64`.

* **Project File (`GitHubActionTriggerCLI/GitHubActionTriggerCLI.csproj`):**
  - Add `<PublishAot>true</PublishAot>` to enable Native-AOT.
  - Add `<RuntimeIdentifier>osx-arm64</RuntimeIdentifier>` to specify the target runtime.
  - Add `<SelfContained>true</SelfContained>` to create a self-contained application.

* **Build Script (`GitHubActionTriggerOnnxRAGCLI/bld.bash`):**
  - Add `dotnet publish -r osx-arm64 --self-contained -c Release` to publish the application for `osx-arm64`.

* **Documentation (`README.md`):**
  - Add instructions for generating a Native-AOT application for `osx-arm64`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aitrailblazer/K8sLogBotRAG/pull/51?shareId=65567d23-15a7-4092-88f2-6494af844305).